### PR TITLE
Add contributing guide, PR template, and issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Something in FlyPath does not work as expected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The more detail you give,
+        the faster it can be fixed. If a mission was rejected by DJI Fly, please
+        attach the KMZ if you can.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, and what went wrong?
+      placeholder: I generated a 2D mapping mission and DJI Fly rejected the file.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      placeholder: The mission should load and fly.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: A numbered list is ideal.
+      placeholder: |
+        1. Select a polygon layer
+        2. Set altitude to 60 m
+        3. Click Generate
+        4. Send to RC
+    validations:
+      required: true
+  - type: input
+    id: qgis-version
+    attributes:
+      label: QGIS version
+      placeholder: "3.44.10"
+    validations:
+      required: true
+  - type: input
+    id: drone
+    attributes:
+      label: Drone model
+      placeholder: DJI Mini 4 Pro
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows 11
+        - Windows 10
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, the mission KMZ, or log output can be pasted or attached here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contact the maintainer
+    url: mailto:salar@dronnix.com
+    about: For anything that is not a bug or feature request, email Salar at Dronnix.
+  - name: FlyPath on the QGIS Plugin Repository
+    url: https://plugins.qgis.org/plugins/FlyPath/
+    about: Install FlyPath from the QGIS Plugin Manager.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an idea or improvement for FlyPath
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Describe what you are trying to do and why, so the
+        feature can be designed to fit real missions.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that FlyPath does not let you do today?
+      placeholder: When I plan a corridor I want to...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the feature look like in the plugin?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      validations:
+        required: false
+  - type: input
+    id: drone
+    attributes:
+      label: Which drone would this be for?
+      placeholder: DJI Air 3S
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!-- Thanks for contributing to FlyPath. Please fill this in so the review is quick. -->
+
+## What does this change do?
+
+<!-- A short description of the change and why it is needed. Link any related issue with #number. -->
+
+## How was it tested?
+
+<!-- Which drone, which QGIS version, and what you checked. If you generated a mission, say what you flew or inspected. -->
+
+- [ ] Ran `python -m pyflakes $(git ls-files '*.py')`
+- [ ] Ran `python tools/check_qt6_enums.py`
+- [ ] Ran `python -m pytest -q tests`
+
+## Checklist
+
+- [ ] The change is focused on one thing
+- [ ] Works on QGIS 3 (PyQt5) and, where relevant, QGIS 4 (PyQt6)
+- [ ] Tests added or updated for changed logic (routing, splitting, contours)
+- [ ] My commit email is the one I want credited in the project history
+
+<!-- The maintainer (Salar Ghaffarian) reviews and merges. Merging, tagging, and releases are done by the maintainer. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to FlyPath
+
+Thanks for your interest in improving FlyPath. This guide covers how to propose
+changes. It applies to everyone outside the core maintainer, and keeps the
+history clean and the review simple.
+
+## How contributions work
+
+FlyPath uses a **fork and pull request** workflow. You do not need write access
+to the repository. You work on your own fork and open a pull request; the
+maintainer reviews it and merges it.
+
+Merging to `main`, tagging versions, and publishing releases are done by the
+maintainer (Salar Ghaffarian) only.
+
+## Before you start
+
+- Enable **two factor authentication** on your GitHub account.
+- Your commits are credited to whatever email your git is configured with, so
+  set it to an address you are happy to have shown in the public history:
+  `git config user.email you@example.com`. If you are part of Dronnix and want
+  your commits to represent Dronnix, use your `@dronnix.com` address; otherwise
+  your own email is fine.
+
+## Step by step
+
+1. **Fork** the repository on GitHub (the Fork button on
+   `https://github.com/dronnix-io/FlyPath`).
+
+2. **Clone your fork** and add the main repository as `upstream`:
+
+   ```bash
+   git clone https://github.com/<your-username>/FlyPath.git
+   cd FlyPath
+   git remote add upstream https://github.com/dronnix-io/FlyPath.git
+   ```
+
+3. **Create a branch** off an up to date `main`:
+
+   ```bash
+   git fetch upstream
+   git checkout -b my-change upstream/main
+   ```
+
+   Use a short, descriptive branch name (for example `fix-auto-direction`,
+   `takeoff-zone-tolerance`).
+
+4. **Make your change.** Keep each pull request focused on one thing. Match the
+   style of the surrounding code.
+
+5. **Run the checks locally** before pushing:
+
+   ```bash
+   python -m pyflakes $(git ls-files '*.py')
+   python tools/check_qt6_enums.py
+   python -m pytest -q tests
+   ```
+
+   The same checks run automatically on every pull request through CI, so a
+   green run here means a green run there.
+
+6. **Push to your fork** and open a pull request against `dronnix-io/FlyPath`
+   `main`:
+
+   ```bash
+   git push origin my-change
+   ```
+
+   GitHub will offer a "Compare and pull request" button. Fill in the pull
+   request template so the reviewer knows what changed and how you tested it.
+
+## Keeping your branch current
+
+If `main` moves ahead while your pull request is open:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+git push origin my-change --force-with-lease
+```
+
+## Guidelines
+
+- **Qt 5 and Qt 6 compatibility.** FlyPath runs on QGIS 3 (PyQt5) and QGIS 4
+  (PyQt6). Use `qgis.PyQt` imports and scoped enums with a `getattr` fallback so
+  both work. The Qt6 enum check enforces this.
+- **Tests.** Logic that can be tested without QGIS (routing, splitting,
+  contours) has pure Python tests under `tests/`. Add or update tests when you
+  change that logic.
+- **Commit messages.** Write a short summary line in the imperative mood, then a
+  blank line and detail if needed.
+- **Scope.** Large or structural changes are easier to land if you open an issue
+  first to agree on the approach.
+
+## Reporting bugs and requesting features
+
+Open an issue at
+`https://github.com/dronnix-io/FlyPath/issues`. For a bug, include your QGIS
+version, your drone model, the steps to reproduce, and the mission KMZ if you
+can share it.
+
+## Questions and contact
+
+For anything about a specific change, open an issue or comment on your pull
+request so the discussion stays with the code. For anything else, reach the
+maintainer at [salar@dronnix.com](mailto:salar@dronnix.com).


### PR DESCRIPTION
Adds contributor documentation so anyone can contribute to FlyPath and knows how.

## What this adds
- **CONTRIBUTING.md** describing the fork and pull request workflow: fork, clone, add `upstream`, branch off `main`, run the local checks (`pyflakes`, the Qt6 scoped-enum check, `pytest`), push, and open a PR. Covers Qt5/Qt6 compatibility, tests, commit messages, and keeping a branch current.
- **.github/pull_request_template.md** so every new PR opens with a what/how-tested/checklist.
- **.github/ISSUE_TEMPLATE/** bug report and feature request forms (bug asks for QGIS version, drone model, OS, steps), plus a config that points other questions to salar@dronnix.com and links the QGIS plugin page.

Merging, tagging, and releases stay with the maintainer. Contact for anything else is salar@dronnix.com.