### PR TITLE
Linux export, RC detection and manual directory selection (#12)

### DIFF
--- a/flypath_dialog.py
+++ b/flypath_dialog.py
@@ -699,8 +699,11 @@ class _RcFolderBrowser(QDialog):
         finally:
             QApplication.restoreOverrideCursor()
         for name in names:
-            item = QTreeWidgetItem([name])
-            item.setData(0, _ROLE_PARTS, parts + [name])
+            name = name.split('\0')
+            if len(name) == 1:
+                name.append(name[0])
+            item = QTreeWidgetItem([name[1]])
+            item.setData(0, _ROLE_PARTS, parts + [name[0]])
             item.setData(0, _ROLE_LOADED, False)
             item.addChild(QTreeWidgetItem(['…']))   # dummy → shows arrow
             if parent_item is None:

--- a/flypath_dialog.py
+++ b/flypath_dialog.py
@@ -20,7 +20,7 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.PyQt.QtCore import (
     Qt, QObject, QEvent, QSettings, QVariant, QSize, QPointF, QUrl, pyqtSignal,
-    QStorageInfo, QDir,
+    QDir,
 )
 from qgis.PyQt.QtGui import (
     QColor, QFont, QPixmap, QPainter, QPen, QPolygonF, QImage, QDesktopServices,

--- a/flypath_dialog.py
+++ b/flypath_dialog.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import subprocess  # nosec B404
+import sys
 import tempfile
 import zipfile
 
@@ -19,6 +20,7 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.PyQt.QtCore import (
     Qt, QObject, QEvent, QSettings, QVariant, QSize, QPointF, QUrl, pyqtSignal,
+    QStorageInfo, QDir,
 )
 from qgis.PyQt.QtGui import (
     QColor, QFont, QPixmap, QPainter, QPen, QPolygonF, QImage, QDesktopServices,
@@ -103,6 +105,7 @@ from qgis.core import (
     QgsCoordinateTransform,
     QgsDistanceArea,
     QgsNetworkAccessManager,
+    QgsMessageLog,
 )
 from .map_tools import PolygonDrawTool, LineDrawTool, VertexPickTool
 from .grid_planner import (
@@ -4662,6 +4665,8 @@ class FlyPathDialog(QWidget):
         finally:
             QApplication.restoreOverrideCursor()
 
+        QgsMessageLog.logMessage(f'status: {status}, missions: {missions}, wp_path: {wp_path}, detail: {detail}')
+
         if status == 'ok':
             self._set_rc_target(wp_path)
             self._populate_mission_combo(missions)
@@ -4735,27 +4740,39 @@ class FlyPathDialog(QWidget):
 
     def _list_shell_children(self, parts):
         """Return the child folder names of a shell path (parts from This PC)."""
-        ps_exe = os.path.join(
-            os.environ.get('SystemRoot', r'C:\Windows'),
-            r'System32\WindowsPowerShell\v1.0\powershell.exe'
-        )
-        tmp_dir = tempfile.mkdtemp(prefix='flypath_')
-        try:
-            sp = os.path.join(tmp_dir, 'children.ps1')
-            with open(sp, 'w', encoding='utf-8') as fh:
-                fh.write(self._shell_children_script(parts))
+        if sys.platform == 'win32':
+            ps_exe = os.path.join(
+                os.environ.get('SystemRoot', r'C:\Windows'),
+                r'System32\WindowsPowerShell\v1.0\powershell.exe'
+            )
+            tmp_dir = tempfile.mkdtemp(prefix='flypath_')
             try:
-                r = subprocess.run(  # nosec B603
-                    [ps_exe, '-NoProfile', '-NonInteractive', '-STA',
-                     '-ExecutionPolicy', 'Bypass', '-File', sp],
-                    capture_output=True, text=True, timeout=40,
-                    creationflags=_NO_WINDOW, startupinfo=_STARTUPINFO
-                )
-            except Exception:
-                return []
-            return [ln[2:] for ln in r.stdout.splitlines() if ln.startswith('D|')]
-        finally:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+                sp = os.path.join(tmp_dir, 'children.ps1')
+                with open(sp, 'w', encoding='utf-8') as fh:
+                    fh.write(self._shell_children_script(parts))
+                try:
+                    r = subprocess.run(  # nosec B603
+                        [ps_exe, '-NoProfile', '-NonInteractive', '-STA',
+                        '-ExecutionPolicy', 'Bypass', '-File', sp],
+                        capture_output=True, text=True, timeout=40,
+                        creationflags=_NO_WINDOW, startupinfo=_STARTUPINFO
+                    )
+                except Exception:
+                    return []
+                return [ln[2:] for ln in r.stdout.splitlines() if ln.startswith('D|')]
+            finally:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+        elif sys.platform == 'linux':
+            if len(parts) == 0:
+                # We are filling in root, lets leave a few shortcuts
+                rv = ['/\0System Root', QDir.homePath() + '\0Home']
+                gvfspath = f'/run/user/{os.getuid()}/gvfs'
+                if os.path.isdir(gvfspath):
+                    rv.extend([f'{os.path.join(gvfspath, x)}\0{x}' for x in os.listdir(gvfspath)])
+                return rv
+
+            parts = os.path.join('/', *parts)
+            return [d for d in sorted(os.listdir(parts)) if os.path.isdir(os.path.join(parts, d))]
 
     @staticmethod
     def _shell_children_script(parts):

--- a/flypath_dialog.py
+++ b/flypath_dialog.py
@@ -4667,9 +4667,12 @@ class FlyPathDialog(QWidget):
             if drive_path:
                 status, missions = self._list_missions_from_dir(drive_path)
                 wp_path, detail = drive_path, ''
-            else:
+            elif sys.platform == 'win32':
                 # 2) The usual case: an MTP device connected over USB.
                 status, wp_path, missions, detail = self._list_rc_missions()
+            else:
+                # not found by 1) and on a non windows system, just give up
+                status = 'not_connected'
         finally:
             QApplication.restoreOverrideCursor()
 
@@ -4701,7 +4704,6 @@ class FlyPathDialog(QWidget):
                 'folder yourself.'
             )
         else:
-            # ONR: detail below in linux is a powershell not found error
             self.rcStatusLabel.setText('Could not read the RC')
             if detail:
                 QMessageBox.warning(self, 'Could Not Read RC', detail)
@@ -4726,7 +4728,11 @@ class FlyPathDialog(QWidget):
         finally:
             QApplication.restoreOverrideCursor()
 
-        display = '\\'.join(parts) # ONR: not like this on linux!
+        if sys.platform == 'win32':
+            display = '\\'.join(parts) # ONR: not like this on linux!
+        else:
+            # I'm pretty sure linux and osx should have a similar output
+            display = os.path.join(*parts)
         if status == 'ok':
             self._set_rc_target(display)
             self._populate_mission_combo(missions)

--- a/flypath_dialog.py
+++ b/flypath_dialog.py
@@ -105,7 +105,6 @@ from qgis.core import (
     QgsCoordinateTransform,
     QgsDistanceArea,
     QgsNetworkAccessManager,
-    QgsMessageLog,
 )
 from .map_tools import PolygonDrawTool, LineDrawTool, VertexPickTool
 from .grid_planner import (
@@ -4622,22 +4621,31 @@ class FlyPathDialog(QWidget):
         """
         rel = os.path.join(*_RC_REL_PARTS)
         roots = []
-        try:
-            import ctypes
-            k32 = ctypes.windll.kernel32
-            bitmask = k32.GetLogicalDrives()
-            for i in range(26):
-                if not (bitmask >> i) & 1:
-                    continue
-                root = chr(ord('A') + i) + ':\\'
-                # 2 = removable, 3 = fixed; skip optical/network/etc. to avoid
-                # slow probes or "insert disk" prompts.
-                if k32.GetDriveTypeW(ctypes.c_wchar_p(root)) in (2, 3):
-                    roots.append(root)
-        except Exception:
-            import string
-            roots = [c + ':\\' for c in string.ascii_uppercase
-                     if os.path.isdir(c + ':\\')]
+        if sys.platform == 'win32':
+            try:
+                import ctypes
+                k32 = ctypes.windll.kernel32
+                bitmask = k32.GetLogicalDrives()
+                for i in range(26):
+                    if not (bitmask >> i) & 1:
+                        continue
+                    root = chr(ord('A') + i) + ':\\'
+                    # 2 = removable, 3 = fixed; skip optical/network/etc. to avoid
+                    # slow probes or "insert disk" prompts.
+                    if k32.GetDriveTypeW(ctypes.c_wchar_p(root)) in (2, 3):
+                        roots.append(root)
+            except Exception:
+                import string
+                roots = [c + ':\\' for c in string.ascii_uppercase
+                        if os.path.isdir(c + ':\\')]
+        elif sys.platform == 'linux':
+            # This will only work when your distro uses GVFS, and even then I only tested on
+            # a couple of debian based distributions
+            gvfspath = os.path.join(os.getenv('XDG_RUNTIME_DIR', f'/run/user/{os.getuid()}'), 'gvfs')
+            # because MTP devices will present individual "drives", the paths found are parents to the
+            # ones we need
+            for base in [os.path.join(gvfspath, x) for x in os.listdir(gvfspath) if x.startswith('mtp:')]:
+                roots.extend([os.path.join(base, x) for x in os.listdir(base)])
         for root in roots:
             candidate = os.path.join(root, rel)
             try:
@@ -4664,8 +4672,6 @@ class FlyPathDialog(QWidget):
                 status, wp_path, missions, detail = self._list_rc_missions()
         finally:
             QApplication.restoreOverrideCursor()
-
-        QgsMessageLog.logMessage(f'status: {status}, missions: {missions}, wp_path: {wp_path}, detail: {detail}')
 
         if status == 'ok':
             self._set_rc_target(wp_path)
@@ -4695,6 +4701,7 @@ class FlyPathDialog(QWidget):
                 'folder yourself.'
             )
         else:
+            # ONR: detail below in linux is a powershell not found error
             self.rcStatusLabel.setText('Could not read the RC')
             if detail:
                 QMessageBox.warning(self, 'Could Not Read RC', detail)
@@ -4713,11 +4720,13 @@ class FlyPathDialog(QWidget):
 
         QApplication.setOverrideCursor(_WaitCursor)
         try:
-            status, missions = self._list_missions_at_path(parts)
+            # ONR: will try this on windows, seems redundant to separate for linux
+            # status, missions = self._list_missions_at_path(parts)
+            status, missions = self._list_missions_from_dir(os.path.join(*parts))
         finally:
             QApplication.restoreOverrideCursor()
 
-        display = '\\'.join(parts)
+        display = '\\'.join(parts) # ONR: not like this on linux!
         if status == 'ok':
             self._set_rc_target(display)
             self._populate_mission_combo(missions)
@@ -4766,7 +4775,7 @@ class FlyPathDialog(QWidget):
             if len(parts) == 0:
                 # We are filling in root, lets leave a few shortcuts
                 rv = ['/\0System Root', QDir.homePath() + '\0Home']
-                gvfspath = f'/run/user/{os.getuid()}/gvfs'
+                gvfspath = os.path.join(os.getenv('XDG_RUNTIME_DIR', f'/run/user/{os.getuid()}'), 'gvfs')
                 if os.path.isdir(gvfspath):
                     rv.extend([f'{os.path.join(gvfspath, x)}\0{x}' for x in os.listdir(gvfspath)])
                 return rv


### PR DESCRIPTION
<!-- Thanks for contributing to FlyPath. Please fill this in so the review is quick. -->

## What does this change do?

<!-- A short description of the change and why it is needed. Link any related issue with #number. -->

This PR allows for RC detection and manual directory selection on Linux, as per issue #12 

## How was it tested?

<!-- Which drone, which QGIS version, and what you checked. If you generated a mission, say what you flew or inspected. -->

Tested manually in QGIS 3.44-7 on linux, and QGIS 4.2.2 on Windows to make sure it doesn't break things, no automated test ran. Using the DJI RC2.

- [ ] Ran `python -m pyflakes $(git ls-files '*.py')`
- [ ] Ran `python tools/check_qt6_enums.py`
- [ ] Ran `python -m pytest -q tests`

## Checklist

- [ X ] The change is focused on one thing
- [ X ] Works on QGIS 3 (PyQt5) and, where relevant, QGIS 4 (PyQt6)
- [ ] Tests added or updated for changed logic (routing, splitting, contours)
- [ X ] My commit email is the one I want credited in the project history

<!-- The maintainer (Salar Ghaffarian) reviews and merges. Merging, tagging, and releases are done by the maintainer. -->

@salarghaffarian please check flypath_dialog.py:4727. I changed the function that verifies a set path has waypoints on it, as you have two ways available and the one I changed to does not imply using Windows specific code. I did test it to work on my RC2 but it may not be consistent with other controllers? It is an easy fix to make a decision based on OS there, I just rather have a single code path where possible.
And on that note, I started out trying to make a common, OS agnostic code work for everyone as QT has a lot of primitives for that particular use case, but fell short on the drive letter vs mounted path without resorting to external python libraries. That is always an option if you feel it is worth the trouble, but for now there's just a clear separation wherever that makes sense.
Finally, I would urge you to test and provide feedback, but you may want to hold off merging this for now, as I will dust off my OSX machine as soon as I have a moment and will try to make this work for Mac too, but we can also just open a new issue if you feel that to be more appropriate, of course.